### PR TITLE
Adding ProductDetail Entity

### DIFF
--- a/src/entities/ProductDetail.java
+++ b/src/entities/ProductDetail.java
@@ -1,0 +1,56 @@
+package entities;
+
+import enums.MeasureUnit;
+
+import java.util.List;
+
+public class ProductDetail extends BaseEntity<Long>{
+    private Product product;
+    private String name;
+    private Double price;
+    private MeasureUnit measureUnit;
+    private List<Tax> taxes;
+
+    public ProductDetail() {
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public MeasureUnit getMeasureUnit() {
+        return measureUnit;
+    }
+
+    public void setMeasureUnit(MeasureUnit measureUnit) {
+        this.measureUnit = measureUnit;
+    }
+
+    public List<Tax> getTaxes() {
+        return taxes;
+    }
+
+    public void setTaxes(List<Tax> taxes) {
+        this.taxes = taxes;
+    }
+}


### PR DESCRIPTION
This branch contains the Product Detail entity. A Product detail has the original product that it represents, the name, measure unit, price and taxes of that product at the moment of the creation of tne product detail object.

The reasoning behind this entity is that it stores a before and after of a product. So that, if the product changes in the future (the name, the price, taxes), there's still a copy of what the product was like at the moment of the creation of product detail.