### PR TITLE
Adding OrderDetailProduct entity

### DIFF
--- a/src/entities/OrderDetailProduct.java
+++ b/src/entities/OrderDetailProduct.java
@@ -1,12 +1,12 @@
 package entities;
 
-import enums.MeasureUnit;
+import enums.MeasureUnitEnum;
 
 public class OrderDetailProduct extends BaseEntity<Long>{
     private FinalProduct finalProduct;
     private String name;
     private Double price;
-    private MeasureUnit measureUnit;
+    private MeasureUnitEnum measureUnit;
 
     public OrderDetailProduct() {
     }
@@ -35,11 +35,11 @@ public class OrderDetailProduct extends BaseEntity<Long>{
         this.price = price;
     }
 
-    public MeasureUnit getMeasureUnit() {
+    public MeasureUnitEnum getMeasureUnit() {
         return measureUnit;
     }
 
-    public void setMeasureUnit(MeasureUnit measureUnit) {
-        this.measureUnit = measureUnit;
+    public void setMeasureUnit(MeasureUnitEnum measureUnitEnum) {
+        this.measureUnit = measureUnitEnum;
     }
 }

--- a/src/entities/OrderDetailProduct.java
+++ b/src/entities/OrderDetailProduct.java
@@ -1,0 +1,45 @@
+package entities;
+
+import enums.MeasureUnit;
+
+public class OrderDetailProduct extends BaseEntity<Long>{
+    private FinalProduct finalProduct;
+    private String name;
+    private Double price;
+    private MeasureUnit measureUnit;
+
+    public OrderDetailProduct() {
+    }
+
+    public FinalProduct getFinalProduct() {
+        return finalProduct;
+    }
+
+    public void setFinalProduct(FinalProduct finalProduct) {
+        this.finalProduct = finalProduct;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public MeasureUnit getMeasureUnit() {
+        return measureUnit;
+    }
+
+    public void setMeasureUnit(MeasureUnit measureUnit) {
+        this.measureUnit = measureUnit;
+    }
+}

--- a/src/entities/Product.java
+++ b/src/entities/Product.java
@@ -1,13 +1,13 @@
 package entities;
 
-import enums.MeasureUnit;
+import enums.MeasureUnitEnum;
 import java.util.ArrayList;
 import java.util.List;
 
 public class Product extends BaseEntity<Long>{
     private String name;
     private Double price;
-    private MeasureUnit measureUnit;
+    private MeasureUnitEnum measureUnitEnum;
     private List<FinalProductProduct> finalProductProducts;
     private List<Tax> taxes;
 
@@ -31,12 +31,12 @@ public class Product extends BaseEntity<Long>{
         this.price = price;
     }
 
-    public MeasureUnit getMeasureUnit() {
-        return measureUnit;
+    public MeasureUnitEnum getMeasureUnit() {
+        return measureUnitEnum;
     }
 
-    public void setMeasureUnit(MeasureUnit measureUnit) {
-        this.measureUnit = measureUnit;
+    public void setMeasureUnit(MeasureUnitEnum measureUnitEnum) {
+        this.measureUnitEnum = measureUnitEnum;
     }
 
     public List<FinalProductProduct> getFinalProductProducts() {

--- a/src/enums/MeasureUnitEnum.java
+++ b/src/enums/MeasureUnitEnum.java
@@ -1,6 +1,6 @@
 package enums;
 
-public enum MeasureUnit {
+public enum MeasureUnitEnum {
     POUNDS,
     GRAMS,
     UNIT,


### PR DESCRIPTION
This branch contains the OrderDetailProduct entity. An OrderDetailProduct will be used to store the content of a product when placing an order. For example, if the product "hamburger" is changed in the future to "double cheeseburger", the original product information will still be stored in the OrderDetailProduct, and therefore in the order.

OrderDetailProduct has a FinalProduct attrbitute (the original final product that it represents), it's name, price and MeasureUnit. Attributes like order detail and order detail taxes will also be added in the future.