### PR TITLE
Adding OrderDetailTax entity

### DIFF
--- a/src/entities/OrderDetailProduct.java
+++ b/src/entities/OrderDetailProduct.java
@@ -2,11 +2,14 @@ package entities;
 
 import enums.MeasureUnitEnum;
 
+import java.util.List;
+
 public class OrderDetailProduct extends BaseEntity<Long>{
     private FinalProduct finalProduct;
     private String name;
     private Double price;
     private MeasureUnitEnum measureUnit;
+    private List<OrderDetailTax> orderDetailTaxes;
 
     public OrderDetailProduct() {
     }
@@ -39,7 +42,15 @@ public class OrderDetailProduct extends BaseEntity<Long>{
         return measureUnit;
     }
 
-    public void setMeasureUnit(MeasureUnitEnum measureUnitEnum) {
-        this.measureUnit = measureUnitEnum;
+    public void setMeasureUnit(MeasureUnitEnum measureUnit) {
+        this.measureUnit = measureUnit;
+    }
+
+    public List<OrderDetailTax> getOrderDetailTaxes() {
+        return orderDetailTaxes;
+    }
+
+    public void setOrderDetailTaxes(List<OrderDetailTax> orderDetailTaxes) {
+        this.orderDetailTaxes = orderDetailTaxes;
     }
 }

--- a/src/entities/OrderDetailTax.java
+++ b/src/entities/OrderDetailTax.java
@@ -1,0 +1,43 @@
+package entities;
+
+public class OrderDetailTax extends BaseEntity<Long>{
+    private Tax tax;
+    private OrderDetailProduct orderDetailProduct;
+    private String taxName;
+    private Double taxPercentage;
+
+    public OrderDetailTax() {
+    }
+
+    public Tax getTax() {
+        return tax;
+    }
+
+    public void setTax(Tax tax) {
+        this.tax = tax;
+    }
+
+    public OrderDetailProduct getOrderDetailProduct() {
+        return orderDetailProduct;
+    }
+
+    public void setOrderDetailProduct(OrderDetailProduct orderDetailProduct) {
+        this.orderDetailProduct = orderDetailProduct;
+    }
+
+    public String getTaxName() {
+        return taxName;
+    }
+
+    public void setTaxName(String taxName) {
+        this.taxName = taxName;
+    }
+
+    public Double getTaxPercentage() {
+        return taxPercentage;
+    }
+
+    public void setTaxPercentage(Double taxPercentage) {
+        this.taxPercentage = taxPercentage;
+    }
+}


### PR DESCRIPTION
This branch contains the OrderDetailTax entity. An order detail tax is going to be used to store the taxes of an order detail and order detail product. First of all, we need to capture the taxes of a product at the moment an order is made, in case it changes in the future. But also we need to allow an order detail has its own taxes that might or might not require a product. 

So an OrderDetailProduct has a list of OrderDetailTax, to represent the taxes of a product, but an OrderDetail will also contain a List of OrderDetailTax, to represent the taxes of an OrderDetail.

I also changed some variable names so that they have consistency between each other.

In OrderDetailProduct the name, price and measureUnit were changed to productName, productPrice, and productMeasureUnit.
In OrderDetailTax the name attribute was changed to taxName