### PR TITLE
Adding Chef Order Detail Entity

### DIFF
--- a/src/entities/ChefOrderDetail.java
+++ b/src/entities/ChefOrderDetail.java
@@ -1,0 +1,34 @@
+package entities;
+
+public class ChefOrderDetail extends BaseEntity<Long>{
+    private Chef chef;
+    private OrderDetail orderDetail;
+    private Double preparationTime;
+
+    public ChefOrderDetail() {
+    }
+
+    public Chef getChef() {
+        return chef;
+    }
+
+    public void setChef(Chef chef) {
+        this.chef = chef;
+    }
+
+    public OrderDetail getOrderDetail() {
+        return orderDetail;
+    }
+
+    public void setOrderDetail(OrderDetail orderDetail) {
+        this.orderDetail = orderDetail;
+    }
+
+    public Double getPreparationTime() {
+        return preparationTime;
+    }
+
+    public void setPreparationTime(Double preparationTime) {
+        this.preparationTime = preparationTime;
+    }
+}

--- a/src/entities/OrderDetail.java
+++ b/src/entities/OrderDetail.java
@@ -1,0 +1,46 @@
+package entities;
+
+import java.util.List;
+
+public class OrderDetail extends BaseEntity<Long>{
+    private OrderDetailProduct orderDetailProduct;
+    private Double quantity;
+    private Double price;
+    private List<OrderDetailTax> orderDetailTaxes;
+
+    public OrderDetail() {
+    }
+
+    public OrderDetailProduct getOrderDetailProduct() {
+        return orderDetailProduct;
+    }
+
+    public void setOrderDetailProduct(OrderDetailProduct orderDetailProduct) {
+        this.orderDetailProduct = orderDetailProduct;
+    }
+
+    public Double getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Double quantity) {
+        this.quantity = quantity;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public List<OrderDetailTax> getOrderDetailTaxes() {
+        return orderDetailTaxes;
+    }
+
+    public void setOrderDetailTaxes(List<OrderDetailTax> orderDetailTaxes) {
+        this.orderDetailTaxes = orderDetailTaxes;
+    }
+}
+

--- a/src/entities/OrderDetail.java
+++ b/src/entities/OrderDetail.java
@@ -7,6 +7,7 @@ public class OrderDetail extends BaseEntity<Long>{
     private Double quantity;
     private Double price;
     private List<OrderDetailTax> orderDetailTaxes;
+    private ChefOrderDetail chefOrderDetail;
 
     public OrderDetail() {
     }
@@ -41,6 +42,14 @@ public class OrderDetail extends BaseEntity<Long>{
 
     public void setOrderDetailTaxes(List<OrderDetailTax> orderDetailTaxes) {
         this.orderDetailTaxes = orderDetailTaxes;
+    }
+
+    public ChefOrderDetail getChefOrderDetail() {
+        return chefOrderDetail;
+    }
+
+    public void setChefOrderDetail(ChefOrderDetail chefOrderDetail) {
+        this.chefOrderDetail = chefOrderDetail;
     }
 }
 

--- a/src/entities/OrderDetailProduct.java
+++ b/src/entities/OrderDetailProduct.java
@@ -10,6 +10,7 @@ public class OrderDetailProduct extends BaseEntity<Long>{
     private Double price;
     private MeasureUnitEnum measureUnit;
     private List<OrderDetailTax> orderDetailTaxes;
+    private OrderDetail orderDetail;
 
     public OrderDetailProduct() {
     }
@@ -52,5 +53,13 @@ public class OrderDetailProduct extends BaseEntity<Long>{
 
     public void setOrderDetailTaxes(List<OrderDetailTax> orderDetailTaxes) {
         this.orderDetailTaxes = orderDetailTaxes;
+    }
+
+    public OrderDetail getOrderDetail() {
+        return orderDetail;
+    }
+
+    public void setOrderDetail(OrderDetail orderDetail) {
+        this.orderDetail = orderDetail;
     }
 }

--- a/src/entities/OrderDetailTax.java
+++ b/src/entities/OrderDetailTax.java
@@ -5,6 +5,7 @@ public class OrderDetailTax extends BaseEntity<Long>{
     private OrderDetailProduct orderDetailProduct;
     private String taxName;
     private Double taxPercentage;
+    private OrderDetail orderDetail;
 
     public OrderDetailTax() {
     }
@@ -39,5 +40,13 @@ public class OrderDetailTax extends BaseEntity<Long>{
 
     public void setTaxPercentage(Double taxPercentage) {
         this.taxPercentage = taxPercentage;
+    }
+
+    public OrderDetail getOrderDetail() {
+        return orderDetail;
+    }
+
+    public void setOrderDetail(OrderDetail orderDetail) {
+        this.orderDetail = orderDetail;
     }
 }


### PR DESCRIPTION
This branch contains the ChefOrderDetail entity. A Chef Order Detail is the entity that relates Chef to Order Detail. An order can have many items, many order details, so an order can also have many chefs. For example, if a steak and dessert are ordered, those 2 meals can be prepared by 2 different Chefs with 2 different responsibilities. It is important to have a record of who prepared what in an order.

The order class will contain a list of ChefOrderDetails.