### PR TITLE
Adding buildEmployee method to cashier and chef services

### DIFF
--- a/test/util/fixtures/CashierServiceFixtures.java
+++ b/test/util/fixtures/CashierServiceFixtures.java
@@ -27,9 +27,7 @@ public final class CashierServiceFixtures {
 
   public static Cashier buildCashier(Cashier cashierExample) {
     var cashier = new Cashier();
-    cashier.setCode(
-        Optional.ofNullable(cashierExample).map(Cashier::getCode).orElse("testing-code"));
-    UserFixtures.buildUser(cashier, cashierExample);
+    EmployeeFixtures.buildEmployee(cashier, cashierExample);
     return cashier;
   }
 }

--- a/test/util/fixtures/ChefServiceFixtures.java
+++ b/test/util/fixtures/ChefServiceFixtures.java
@@ -27,7 +27,6 @@ public final class ChefServiceFixtures {
 
   public static Chef buildChef(Chef chefExample) {
     var chef = new Chef();
-    chef.setCode(Optional.ofNullable(chefExample).map(Chef::getCode).orElse("testing-code"));
     EmployeeFixtures.buildEmployee(chef, chefExample);
     return chef;
   }


### PR DESCRIPTION
In this branch, i added the buildEmployee method to cashier and removed the line that sets a default code in the chef service fixtures, because the method buildEmployee sets the default code.