### PR TITLE
Removing setting chef code in the chefServiceFixtures

### DIFF
--- a/test/util/fixtures/ChefServiceFixtures.java
+++ b/test/util/fixtures/ChefServiceFixtures.java
@@ -2,7 +2,6 @@ package util.fixtures;
 
 import entities.Chef;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -27,7 +26,6 @@ public final class ChefServiceFixtures {
 
   public static Chef buildChef(Chef chefExample) {
     var chef = new Chef();
-    chef.setCode(Optional.ofNullable(chefExample).map(Chef::getCode).orElse("testing-code"));
     EmployeeFixtures.buildEmployee(chef, chefExample);
     return chef;
   }

--- a/test/util/fixtures/EmployeeFixtures.java
+++ b/test/util/fixtures/EmployeeFixtures.java
@@ -1,17 +1,13 @@
 package util.fixtures;
 
 import entities.Employee;
-import entities.User;
-import util.BaseEntityUtil;
-import util.EmployeeUtil;
-import util.UserUtil;
-
 import java.util.Optional;
 
 public final class EmployeeFixtures {
-    public static Employee buildEmployee(Employee employee, Employee employeeExample) {
-        UserFixtures.buildUser(employee, employeeExample);
-        employee.setCode(Optional.ofNullable(employeeExample).map(Employee::getCode).orElse("testing-code"));
-        return employee;
-    }
+  public static Employee buildEmployee(Employee employee, Employee employeeExample) {
+    UserFixtures.buildUser(employee, employeeExample);
+    employee.setCode(
+        Optional.ofNullable(employeeExample).map(Employee::getCode).orElse("testing-code"));
+    return employee;
+  }
 }


### PR DESCRIPTION
This branch fixes chef service fixtures, removing the line that sets the code in that class, becase the EmployeeFixtures.buildEmployee(chef, chefExample) creates a default code.