### PR TITLE
Removing Optional return values from services

### DIFF
--- a/src/services/implementation/BaseServiceImpl.java
+++ b/src/services/implementation/BaseServiceImpl.java
@@ -37,14 +37,14 @@ public abstract class BaseServiceImpl<E extends BaseEntity<K>, K extends Seriali
   }
 
   @Override
-  public Optional<E> insert(E entity) {
+  public E insert(E entity) {
     entity.setId(this.currentId);
     entity.setStatus(StatusEnum.ACTIVE);
     entity.setCreatedAt(Instant.now());
     entity.setUpdatedAt(Instant.now());
     this.currentId = this.generateNextId.apply(this.currentId);
     this.entities.add(entity);
-    return Optional.of(entity);
+    return entity;
   }
 
   @Override
@@ -59,22 +59,22 @@ public abstract class BaseServiceImpl<E extends BaseEntity<K>, K extends Seriali
   }
 
   @Override
-  public Optional<E> delete(K id) {
+  public E delete(K id) {
     Optional.ofNullable(id).orElseThrow(IdNullPointerException::new);
     var entity = this.findById(id).get();
     entity.setStatus(StatusEnum.DELETED);
     entity.setUpdatedAt(Instant.now());
-    return Optional.of(entity);
+    return entity;
   }
 
   @Override
-  public Optional<E> update(E entity) {
+  public E update(E entity) {
     Optional.ofNullable(entity).orElseThrow(NullEntityException::new);
     Optional.ofNullable(entity.getId()).orElseThrow(IdNullPointerException::new);
     var existingEntity = this.findById(entity.getId()).get();
     entity.setUpdatedAt(Instant.now());
     var updatedEntity = fetchEntity.apply(existingEntity, entity);
-    return Optional.of(updatedEntity);
+    return updatedEntity;
   }
 
   @Override

--- a/src/services/interfaces/BaseService.java
+++ b/src/services/interfaces/BaseService.java
@@ -4,13 +4,13 @@ import java.util.Collection;
 import java.util.Optional;
 
 public interface BaseService<E, K> {
-  Optional<E> insert(E entity);
+  E insert(E entity);
 
   Optional<E> findById(K id);
 
-  Optional<E> delete(K id);
+  E delete(K id);
 
-  Optional<E> update(E entity);
+  E update(E entity);
 
   Collection<E> findAll();
 }

--- a/test/cashier/CashierServiceTest.java
+++ b/test/cashier/CashierServiceTest.java
@@ -1,19 +1,18 @@
 package cashier;
 
-import static org.junit.Assert.assertEquals;
-
 import entities.Cashier;
 import enums.IocServices;
 import exceptions.services.EntityNotFoundException;
 import exceptions.services.IdNullPointerException;
 import exceptions.services.NullEntityException;
 import ioc.Ioc;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import services.implementation.CashierServiceImpl;
 import util.fixtures.CashierServiceFixtures;
 import util.fixtures.UserFixtures;
+
+import static org.junit.Assert.assertEquals;
 
 public class CashierServiceTest {
   private CashierServiceImpl cashierService;
@@ -37,13 +36,13 @@ public class CashierServiceTest {
   public void findById_ShouldReturnOptionalOfCashier() {
     var cashier = CashierServiceFixtures.buildCashier();
     var newCashier = cashierService.insert(cashier);
-    assertEquals(newCashier, cashierService.findById(cashier.getId()));
+    assertEquals(newCashier, cashierService.findById(cashier.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var cashier = CashierServiceFixtures.buildCashier();
-    var newCashier = cashierService.insert(cashier).get();
+    var newCashier = cashierService.insert(cashier);
     cashierService.delete(newCashier.getId());
     cashierService.findById(newCashier.getId());
   }
@@ -80,9 +79,9 @@ public class CashierServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfCashier() {
+  public void insert_ShouldReturnCashier() {
     var cashier = CashierServiceFixtures.buildCashier();
-    assertEquals(Optional.of(cashier), cashierService.insert(cashier));
+    assertEquals(cashier, cashierService.insert(cashier));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/chef/ChefServiceTest.java
+++ b/test/chef/ChefServiceTest.java
@@ -37,13 +37,13 @@ public class ChefServiceTest {
   public void findById_ShouldReturnOptionalOfChef() {
     var chef = ChefServiceFixtures.buildChef();
     var newChef = chefService.insert(chef);
-    assertEquals(newChef, chefService.findById(chef.getId()));
+    assertEquals(newChef, chefService.findById(chef.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var chef = ChefServiceFixtures.buildChef();
-    var newChef = chefService.insert(chef).get();
+    var newChef = chefService.insert(chef);
     chefService.delete(newChef.getId());
     chefService.findById(newChef.getId());
   }
@@ -80,9 +80,9 @@ public class ChefServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfChef() {
+  public void insert_ShouldReturnChef() {
     var chef = ChefServiceFixtures.buildChef();
-    assertEquals(Optional.of(chef), chefService.insert(chef));
+    assertEquals(chef, chefService.insert(chef));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/client/ClientServiceTest.java
+++ b/test/client/ClientServiceTest.java
@@ -37,13 +37,13 @@ public class ClientServiceTest {
   public void findById_ShouldReturnOptionalOfClient() {
     var client = ClientServiceFixtures.buildClient();
     var newClient = clientService.insert(client);
-    assertEquals(newClient, clientService.findById(client.getId()));
+    assertEquals(newClient, clientService.findById(client.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var client = ClientServiceFixtures.buildClient();
-    var newClient = clientService.insert(client).get();
+    var newClient = clientService.insert(client);
     clientService.delete(newClient.getId());
     clientService.findById(newClient.getId());
   }
@@ -80,9 +80,9 @@ public class ClientServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfClient() {
+  public void insert_ShouldReturnClient() {
     var client = ClientServiceFixtures.buildClient();
-    assertEquals(Optional.of(client), clientService.insert(client));
+    assertEquals(client, clientService.insert(client));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/finalProduct/FinalProductServiceTest.java
+++ b/test/finalProduct/FinalProductServiceTest.java
@@ -37,13 +37,13 @@ public class FinalProductServiceTest {
   public void findById_ShouldReturnOptionalOfFinalProduct() {
     var finalProduct = FinalProductServiceFixtures.buildFinalProduct();
     var newFinalProduct = finalProductService.insert(finalProduct);
-    assertEquals(newFinalProduct, finalProductService.findById(finalProduct.getId()));
+    assertEquals(newFinalProduct, finalProductService.findById(finalProduct.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var finalProduct = FinalProductServiceFixtures.buildFinalProduct();
-    var newFinalProduct = finalProductService.insert(finalProduct).get();
+    var newFinalProduct = finalProductService.insert(finalProduct);
     finalProductService.delete(newFinalProduct.getId());
     finalProductService.findById(newFinalProduct.getId());
   }
@@ -81,9 +81,9 @@ public class FinalProductServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfFinalProduct() {
+  public void insert_ShouldReturnFinalProduct() {
     var finalProduct = FinalProductServiceFixtures.buildFinalProduct();
-    assertEquals(Optional.of(finalProduct), finalProductService.insert(finalProduct));
+    assertEquals(finalProduct, finalProductService.insert(finalProduct));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/finalProductProduct/FinalProductProductTest.java
+++ b/test/finalProductProduct/FinalProductProductTest.java
@@ -39,13 +39,13 @@ public class FinalProductProductTest {
     var finalProductProduct = FinalProductProductServiceFixtures.buildFinalProductProduct();
     var newFinalProductProduct = finalProductProductService.insert(finalProductProduct);
     assertEquals(
-        newFinalProductProduct, finalProductProductService.findById(finalProductProduct.getId()));
+        newFinalProductProduct, finalProductProductService.findById(finalProductProduct.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var finalProductProduct = FinalProductProductServiceFixtures.buildFinalProductProduct();
-    var newFinalProductProduct = finalProductProductService.insert(finalProductProduct).get();
+    var newFinalProductProduct = finalProductProductService.insert(finalProductProduct);
     finalProductProductService.delete(newFinalProductProduct.getId());
     finalProductProductService.findById(newFinalProductProduct.getId());
   }
@@ -85,10 +85,10 @@ public class FinalProductProductTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfFinalProductProduct() {
+  public void insert_ShouldReturnFinalProductProduct() {
     var finalProductProduct = FinalProductProductServiceFixtures.buildFinalProductProduct();
     assertEquals(
-        Optional.of(finalProductProduct), finalProductProductService.insert(finalProductProduct));
+        finalProductProduct, finalProductProductService.insert(finalProductProduct));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/order/OrderServiceTest.java
+++ b/test/order/OrderServiceTest.java
@@ -38,13 +38,13 @@ public class OrderServiceTest {
   public void findById_ShouldReturnOptionalOfOrder() {
     var order = OrderServiceFixtures.buildOrder();
     var newOrder = orderService.insert(order);
-    assertEquals(newOrder, orderService.findById(order.getId()));
+    assertEquals(newOrder, orderService.findById(order.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var order = OrderServiceFixtures.buildOrder();
-    var newOrder = orderService.insert(order).get();
+    var newOrder = orderService.insert(order);
     orderService.delete(newOrder.getId());
     orderService.findById(newOrder.getId());
   }
@@ -81,9 +81,9 @@ public class OrderServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfOrder() {
+  public void insert_ShouldReturnOrder() {
     var order = OrderServiceFixtures.buildOrder();
-    assertEquals(Optional.of(order), orderService.insert(order));
+    assertEquals(order, orderService.insert(order));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/orderDetail/OrderDetailServiceTest.java
+++ b/test/orderDetail/OrderDetailServiceTest.java
@@ -37,13 +37,13 @@ public class OrderDetailServiceTest {
   public void findById_ShouldReturnOptionalOfOrderDetail() {
     var orderDetail = OrderDetailServiceFixtures.buildOrderDetail();
     var newOrderDetail = orderDetailService.insert(orderDetail);
-    assertEquals(newOrderDetail, orderDetailService.findById(orderDetail.getId()));
+    assertEquals(newOrderDetail, orderDetailService.findById(orderDetail.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var orderDetail = OrderDetailServiceFixtures.buildOrderDetail();
-    var newOrderDetail = orderDetailService.insert(orderDetail).get();
+    var newOrderDetail = orderDetailService.insert(orderDetail);
     orderDetailService.delete(newOrderDetail.getId());
     orderDetailService.findById(newOrderDetail.getId());
   }
@@ -79,9 +79,9 @@ public class OrderDetailServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfOrderDetail() {
+  public void insert_ShouldReturnOrderDetail() {
     var orderDetail = OrderDetailServiceFixtures.buildOrderDetail();
-    assertEquals(Optional.of(orderDetail), orderDetailService.insert(orderDetail));
+    assertEquals(orderDetail, orderDetailService.insert(orderDetail));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/orderDetailProduct/OrderDetailProductServiceTest.java
+++ b/test/orderDetailProduct/OrderDetailProductServiceTest.java
@@ -39,13 +39,13 @@ public class OrderDetailProductServiceTest {
     var orderDetailProduct = OrderDetailProductServiceFixtures.buildOrderDetailProduct();
     var newOrderDetailProduct = orderDetailProductService.insert(orderDetailProduct);
     assertEquals(
-        newOrderDetailProduct, orderDetailProductService.findById(orderDetailProduct.getId()));
+        newOrderDetailProduct, orderDetailProductService.findById(orderDetailProduct.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var orderDetailProduct = OrderDetailProductServiceFixtures.buildOrderDetailProduct();
-    var newOrderDetailProduct = orderDetailProductService.insert(orderDetailProduct).get();
+    var newOrderDetailProduct = orderDetailProductService.insert(orderDetailProduct);
     orderDetailProductService.delete(newOrderDetailProduct.getId());
     orderDetailProductService.findById(newOrderDetailProduct.getId());
   }
@@ -84,10 +84,10 @@ public class OrderDetailProductServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfOrderDetailProduct() {
+  public void insert_ShouldReturnOrderDetailProduct() {
     var orderDetailProduct = OrderDetailProductServiceFixtures.buildOrderDetailProduct();
     assertEquals(
-        Optional.of(orderDetailProduct), orderDetailProductService.insert(orderDetailProduct));
+        orderDetailProduct, orderDetailProductService.insert(orderDetailProduct));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/orderDetailTax/OrderDetailTaxServiceTest.java
+++ b/test/orderDetailTax/OrderDetailTaxServiceTest.java
@@ -38,13 +38,13 @@ public class OrderDetailTaxServiceTest {
   public void findById_ShouldReturnOptionalOfOrderDetailTax() {
     var orderDetailTax = OrderDetailTaxServiceFixtures.buildOrderDetailTax();
     var newOrderDetailTax = orderDetailTaxService.insert(orderDetailTax);
-    assertEquals(newOrderDetailTax, orderDetailTaxService.findById(orderDetailTax.getId()));
+    assertEquals(newOrderDetailTax, orderDetailTaxService.findById(orderDetailTax.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var orderDetailTax = OrderDetailTaxServiceFixtures.buildOrderDetailTax();
-    var newOrderDetailTax = orderDetailTaxService.insert(orderDetailTax).get();
+    var newOrderDetailTax = orderDetailTaxService.insert(orderDetailTax);
     orderDetailTaxService.delete(newOrderDetailTax.getId());
     orderDetailTaxService.findById(newOrderDetailTax.getId());
   }
@@ -82,9 +82,9 @@ public class OrderDetailTaxServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfOrderDetailTax() {
+  public void insert_ShouldReturnOrderDetailTax() {
     var orderDetailTax = OrderDetailTaxServiceFixtures.buildOrderDetailTax();
-    assertEquals(Optional.of(orderDetailTax), orderDetailTaxService.insert(orderDetailTax));
+    assertEquals(orderDetailTax, orderDetailTaxService.insert(orderDetailTax));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/orderTax/OrderTaxServiceTest.java
+++ b/test/orderTax/OrderTaxServiceTest.java
@@ -37,13 +37,13 @@ public class OrderTaxServiceTest {
   public void findById_ShouldReturnOptionalOfOrderTax() {
     var orderTax = OrderTaxServiceFixtures.buildOrderTax();
     var newOrderTax = orderTaxService.insert(orderTax);
-    assertEquals(newOrderTax, orderTaxService.findById(orderTax.getId()));
+    assertEquals(newOrderTax, orderTaxService.findById(orderTax.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var orderTax = OrderTaxServiceFixtures.buildOrderTax();
-    var newOrderTax = orderTaxService.insert(orderTax).get();
+    var newOrderTax = orderTaxService.insert(orderTax);
     orderTaxService.delete(newOrderTax.getId());
     orderTaxService.findById(newOrderTax.getId());
   }
@@ -79,9 +79,9 @@ public class OrderTaxServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfOrderTax() {
+  public void insert_ShouldReturnOrderTax() {
     var orderTax = OrderTaxServiceFixtures.buildOrderTax();
-    assertEquals(Optional.of(orderTax), orderTaxService.insert(orderTax));
+    assertEquals(orderTax, orderTaxService.insert(orderTax));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/product/ProductServiceTest.java
+++ b/test/product/ProductServiceTest.java
@@ -37,13 +37,13 @@ public class ProductServiceTest {
   public void findById_ShouldReturnOptionalOfProduct() {
     var product = ProductServiceFixtures.buildProduct();
     var newProduct = productService.insert(product);
-    assertEquals(newProduct, productService.findById(product.getId()));
+    assertEquals(newProduct, productService.findById(product.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var product = ProductServiceFixtures.buildProduct();
-    var newProduct = productService.insert(product).get();
+    var newProduct = productService.insert(product);
     productService.delete(newProduct.getId());
     productService.findById(newProduct.getId());
   }
@@ -80,9 +80,9 @@ public class ProductServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfProduct() {
+  public void insert_ShouldReturnProduct() {
     var product = ProductServiceFixtures.buildProduct();
-    assertEquals(Optional.of(product), productService.insert(product));
+    assertEquals(product, productService.insert(product));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/stock/StockServiceTest.java
+++ b/test/stock/StockServiceTest.java
@@ -37,13 +37,13 @@ public class StockServiceTest {
   public void findById_ShouldReturnOptionalOfStock() {
     var stock = StockServiceFixtures.buildStock();
     var newStock = stockService.insert(stock);
-    assertEquals(newStock, stockService.findById(stock.getId()));
+    assertEquals(newStock, stockService.findById(stock.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var stock = StockServiceFixtures.buildStock();
-    var newStock = stockService.insert(stock).get();
+    var newStock = stockService.insert(stock);
     stockService.delete(newStock.getId());
     stockService.findById(newStock.getId());
   }
@@ -79,9 +79,9 @@ public class StockServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfStock() {
+  public void insert_ShouldReturnStock() {
     var stock = StockServiceFixtures.buildStock();
-    assertEquals(Optional.of(stock), stockService.insert(stock));
+    assertEquals(stock, stockService.insert(stock));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/stockProduct/StockProductServiceTest.java
+++ b/test/stockProduct/StockProductServiceTest.java
@@ -37,13 +37,13 @@ public class StockProductServiceTest {
   public void findById_ShouldReturnOptionalOfStockProduct() {
     var stockProduct = StockProductServiceFixtures.buildStockProduct();
     var newStockProduct = stockProductService.insert(stockProduct);
-    assertEquals(newStockProduct, stockProductService.findById(stockProduct.getId()));
+    assertEquals(newStockProduct, stockProductService.findById(stockProduct.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var stockProduct = StockProductServiceFixtures.buildStockProduct();
-    var newStockProduct = stockProductService.insert(stockProduct).get();
+    var newStockProduct = stockProductService.insert(stockProduct);
     stockProductService.delete(newStockProduct.getId());
     stockProductService.findById(newStockProduct.getId());
   }
@@ -80,9 +80,9 @@ public class StockProductServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfStockProduct() {
+  public void insert_ShouldReturnStockProduct() {
     var stockProduct = StockProductServiceFixtures.buildStockProduct();
-    assertEquals(Optional.of(stockProduct), stockProductService.insert(stockProduct));
+    assertEquals(stockProduct, stockProductService.insert(stockProduct));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/tax/TaxServiceTest.java
+++ b/test/tax/TaxServiceTest.java
@@ -37,13 +37,13 @@ public class TaxServiceTest {
   public void findById_ShouldReturnOptionalOfTax() {
     var tax = TaxServiceFixtures.buildTax();
     var newTax = taxService.insert(tax);
-    assertEquals(newTax, taxService.findById(tax.getId()));
+    assertEquals(newTax, taxService.findById(tax.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var tax = TaxServiceFixtures.buildTax();
-    var newTax = taxService.insert(tax).get();
+    var newTax = taxService.insert(tax);
     taxService.delete(newTax.getId());
     taxService.findById(newTax.getId());
   }
@@ -80,9 +80,9 @@ public class TaxServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfTax() {
+  public void insert_ShouldReturnTax() {
     var tax = TaxServiceFixtures.buildTax();
-    assertEquals(Optional.of(tax), taxService.insert(tax));
+    assertEquals(tax, taxService.insert(tax));
   }
 
   @Test(expected = IdNullPointerException.class)

--- a/test/waiter/WaiterServiceTest.java
+++ b/test/waiter/WaiterServiceTest.java
@@ -37,13 +37,13 @@ public class WaiterServiceTest {
   public void findById_ShouldReturnOptionalOfWaiter() {
     var waiter = WaiterServiceFixtures.buildWaiter();
     var newWaiter = waiterService.insert(waiter);
-    assertEquals(newWaiter, waiterService.findById(waiter.getId()));
+    assertEquals(newWaiter, waiterService.findById(waiter.getId()).get());
   }
 
   @Test(expected = EntityNotFoundException.class)
   public void findById_ShouldThrowEntityNotFoundException_WhenStatusIsDeleted() {
     var waiter = WaiterServiceFixtures.buildWaiter();
-    var newWaiter = waiterService.insert(waiter).get();
+    var newWaiter = waiterService.insert(waiter);
     waiterService.delete(newWaiter.getId());
     waiterService.findById(newWaiter.getId());
   }
@@ -80,9 +80,9 @@ public class WaiterServiceTest {
   }
 
   @Test
-  public void insert_ShouldReturnOptionalOfWaiter() {
+  public void insert_ShouldReturnWaiter() {
     var waiter = WaiterServiceFixtures.buildWaiter();
-    assertEquals(Optional.of(waiter), waiterService.insert(waiter));
+    assertEquals(waiter, waiterService.insert(waiter));
   }
 
   @Test(expected = IdNullPointerException.class)


### PR DESCRIPTION
In this branch I removed the Optional return values in the insert, update and delete methods in the services. Only findById can return an Optional.