### PR TITLE
Adding QueueManager

### DIFF
--- a/src/main/com/diana/restaurant/entities/QueueMessage.java
+++ b/src/main/com/diana/restaurant/entities/QueueMessage.java
@@ -1,0 +1,37 @@
+package com.diana.restaurant.entities;
+
+public class QueueMessage<T> {
+  private Long priority;
+  private T data;
+  private String queue;
+
+  public QueueMessage() {}
+
+  public Long getPriority() {
+    return priority;
+  }
+
+  public void setPriority(Long priority) {
+    this.priority = priority;
+  }
+
+  public T getData() {
+    return data;
+  }
+
+  public void setData(T data) {
+    this.data = data;
+  }
+
+  public String getQueue() {
+    return queue;
+  }
+
+  public void setQueue(String queue) {
+    this.queue = queue;
+  }
+
+  public Long compareTo(QueueMessage<T> entity) {
+    return (long) Long.compare(this.priority, entity.priority);
+  }
+}

--- a/src/main/com/diana/restaurant/enums/IocQueueManager.java
+++ b/src/main/com/diana/restaurant/enums/IocQueueManager.java
@@ -1,0 +1,5 @@
+package com.diana.restaurant.enums;
+
+public class IocQueueManager {
+  public static final String QUEUE_MANAGER = "queueManager";
+}

--- a/src/main/com/diana/restaurant/enums/Queues.java
+++ b/src/main/com/diana/restaurant/enums/Queues.java
@@ -1,0 +1,6 @@
+package com.diana.restaurant.enums;
+
+public enum Queues {
+  CHECK_INGREDIENTS_QUEUE;
+  public static final Long MAX_QUEUE_CAPACITY = 10000L;
+}

--- a/src/main/com/diana/restaurant/exceptions/KeyNotFoundException.java
+++ b/src/main/com/diana/restaurant/exceptions/KeyNotFoundException.java
@@ -1,0 +1,7 @@
+package com.diana.restaurant.exceptions;
+
+public class KeyNotFoundException extends RuntimeException {
+  public KeyNotFoundException(String entity) {
+    super(entity + " key not found");
+  }
+}

--- a/src/main/com/diana/restaurant/exceptions/ioc/IocKeyNotFoundException.java
+++ b/src/main/com/diana/restaurant/exceptions/ioc/IocKeyNotFoundException.java
@@ -1,7 +1,0 @@
-package com.diana.restaurant.exceptions.ioc;
-
-public class IocKeyNotFoundException extends RuntimeException {
-  public IocKeyNotFoundException() {
-    super("Key not found");
-  }
-}

--- a/src/main/com/diana/restaurant/exceptions/queueManager/QueueOverflowException.java
+++ b/src/main/com/diana/restaurant/exceptions/queueManager/QueueOverflowException.java
@@ -1,0 +1,7 @@
+package com.diana.restaurant.exceptions.queueManager;
+
+public class QueueOverflowException extends RuntimeException {
+  public QueueOverflowException(Long maxCapacity, String queue) {
+    super(queue + " reached max capacity of " + maxCapacity);
+  }
+}

--- a/src/main/com/diana/restaurant/ioc/Ioc.java
+++ b/src/main/com/diana/restaurant/ioc/Ioc.java
@@ -17,11 +17,13 @@ import com.diana.restaurant.controllers.StockProductController;
 import com.diana.restaurant.controllers.TaxController;
 import com.diana.restaurant.controllers.WaiterController;
 import com.diana.restaurant.enums.IocControllers;
+import com.diana.restaurant.enums.IocQueueManager;
 import com.diana.restaurant.enums.IocServices;
+import com.diana.restaurant.exceptions.KeyNotFoundException;
 import com.diana.restaurant.exceptions.ioc.IocDuplicatedKeyException;
-import com.diana.restaurant.exceptions.ioc.IocKeyNotFoundException;
 import com.diana.restaurant.exceptions.ioc.IocKeyNullPointerException;
 import com.diana.restaurant.exceptions.ioc.IocValueNullPointerException;
+import com.diana.restaurant.queue.QueueManager;
 import com.diana.restaurant.services.implementation.CashierServiceImpl;
 import com.diana.restaurant.services.implementation.ChefServiceImpl;
 import com.diana.restaurant.services.implementation.ClientServiceImpl;
@@ -49,6 +51,12 @@ public class Ioc {
   private Ioc() {
     this.registerServices(this.instanceMap);
     this.registerControllers(this.instanceMap);
+    this.registerQueueManager(this.instanceMap);
+  }
+
+  private void registerQueueManager(Map<String, Object> instanceMap) {
+    instanceMap.put(
+        IocQueueManager.QUEUE_MANAGER, new QueueManager(this.get(IocQueueManager.QUEUE_MANAGER)));
   }
 
   private void registerControllers(Map<String, Object> instanceMap) {
@@ -144,6 +152,8 @@ public class Ioc {
 
   public <T> T get(String key) {
     Optional.ofNullable(key).orElseThrow(IocKeyNullPointerException::new);
-    return (T) Optional.ofNullable(instanceMap.get(key)).orElseThrow(IocKeyNotFoundException::new);
+    return (T)
+        Optional.ofNullable(instanceMap.get(key))
+            .orElseThrow(() -> new KeyNotFoundException("Ioc"));
   }
 }

--- a/src/main/com/diana/restaurant/queue/QueueManager.java
+++ b/src/main/com/diana/restaurant/queue/QueueManager.java
@@ -1,0 +1,58 @@
+package com.diana.restaurant.queue;
+
+import com.diana.restaurant.entities.Order;
+import com.diana.restaurant.entities.QueueMessage;
+import com.diana.restaurant.enums.Queues;
+import com.diana.restaurant.exceptions.KeyNotFoundException;
+import com.diana.restaurant.exceptions.queueManager.QueueOverflowException;
+import com.diana.restaurant.exceptions.services.NullEntityException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class QueueManager {
+  private QueueManager queueManager;
+  private final Map<Queues, Queue> instanceMap = new ConcurrentHashMap<>();
+
+  public QueueManager(QueueManager queueManager) {
+    this.queueManager = queueManager;
+  }
+
+  private void registerQueues(Map<Queues, Queue> instanceMap) {
+    instanceMap.putIfAbsent(
+        Queues.CHECK_INGREDIENTS_QUEUE, new PriorityQueue<QueueMessage<Order>>());
+  }
+
+  private <T> T get(String key) {
+    Optional.ofNullable(key).orElseThrow(NullPointerException::new);
+    return (T)
+        Optional.ofNullable(instanceMap.get(key))
+            .orElseThrow(() -> new KeyNotFoundException("Queue"));
+  }
+
+  private void enQueue(String queueName, QueueMessage entity) {
+    var queue =
+        (PriorityQueue)
+            Optional.ofNullable(this.get(queueName))
+                .orElseThrow(() -> new KeyNotFoundException("Queue"));
+    Optional.of(queue)
+        .filter(q -> q.size() <= Queues.MAX_QUEUE_CAPACITY)
+        .orElseThrow(
+            () ->
+                new QueueOverflowException(
+                    Queues.MAX_QUEUE_CAPACITY, Queues.CHECK_INGREDIENTS_QUEUE.toString()));
+    Optional.ofNullable(entity).orElseThrow(NullEntityException::new);
+    queue.add(entity);
+  }
+
+  private void deQueue(String queueName, QueueMessage entity) {
+    var queue =
+        (PriorityQueue)
+            Optional.ofNullable(this.get(queueName))
+                .orElseThrow(() -> new KeyNotFoundException("Queue"));
+    Optional.ofNullable(entity).orElseThrow(NullEntityException::new);
+    queue.remove(entity);
+  }
+}

--- a/src/test/java/com/diana/restaurant/ioc/IocTest.java
+++ b/src/test/java/com/diana/restaurant/ioc/IocTest.java
@@ -1,7 +1,7 @@
 package com.diana.restaurant.ioc;
 
+import com.diana.restaurant.exceptions.KeyNotFoundException;
 import com.diana.restaurant.exceptions.ioc.IocDuplicatedKeyException;
-import com.diana.restaurant.exceptions.ioc.IocKeyNotFoundException;
 import com.diana.restaurant.exceptions.ioc.IocKeyNullPointerException;
 import com.diana.restaurant.exceptions.ioc.IocValueNullPointerException;
 import com.diana.restaurant.util.fixtures.ioc.IocFixtures;
@@ -46,7 +46,7 @@ public class IocTest {
 
   @Test()
   public void get_ShouldThrowIocKeyNotFoundException() {
-    Assertions.assertThrows(IocKeyNotFoundException.class, () -> ioc.get("KeyTest1"));
+    Assertions.assertThrows(KeyNotFoundException.class, () -> ioc.get("KeyTest1"));
   }
 
   @Test


### PR DESCRIPTION
In this branch I added the QueueManager, to manage the queues that the kitchen simulator will have. The CheckIngredientsQueue is a _ConcurrentLinkedQueue_ queue, because it's a list, non-blocking (will return null if empty and not wait until the list has elements to perform an operation) and lock-free. I don't need to have priorities in this queue.